### PR TITLE
Setup JDK to 17 for building with Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
Currently the [build fails for Jitpack](https://jitpack.io/com/github/SmartToolFactory/Compose-BeforeAfter/master-aad665d3c5-1/build.log).

This PR sets the JDK to 17 to enable building with Jitpack. [Here](https://jitpack.io/com/github/nisrulz/Compose-BeforeAfter/update~update-jdk-for-jitpack-f67c03842d-1/build.log) is a functional build on my own branch.

