### PR TITLE
Add Slider move start and end callback to Composables

### DIFF
--- a/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterImageDemo.kt
+++ b/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterImageDemo.kt
@@ -113,7 +113,9 @@ fun BeforeAfterImageDemo() {
 			        ),
 		        ),
                 dividerWidth = 8.dp,
-	        )
+	        ),
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
         Spacer(modifier = Modifier.height(50.dp))
@@ -127,7 +129,9 @@ fun BeforeAfterImageDemo() {
             afterImage = imageAfter,
             contentOrder = ContentOrder.AfterBefore,
             contentScale = contentScale,
-            overlayStyle = OverlayStyle()
+            overlayStyle = OverlayStyle(),
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
         Spacer(modifier = Modifier.height(50.dp))
@@ -147,7 +151,9 @@ fun BeforeAfterImageDemo() {
             beforeImage = imageBefore2,
             afterImage = imageAfter2,
             contentOrder = ContentOrder.AfterBefore,
-            contentScale = contentScale
+            contentScale = contentScale,
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
 
@@ -188,6 +194,8 @@ fun BeforeAfterImageDemo() {
             contentScale = contentScale,
             beforeLabel = {},
             afterLabel = {},
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         ) {
             Text(
                 "${(progress).roundToInt()}%",

--- a/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterLayoutDemo.kt
+++ b/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterLayoutDemo.kt
@@ -1,5 +1,6 @@
 package com.smarttoolfactory.composebeforeafter.demo
 
+import androidx.annotation.OptIn
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.InfiniteTransition
 import androidx.compose.animation.core.RepeatMode
@@ -37,6 +38,7 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.media3.common.util.UnstableApi
 import com.smarttoolfactory.beforeafter.AfterLabel
 import com.smarttoolfactory.beforeafter.BeforeAfterLayout
 import com.smarttoolfactory.beforeafter.BeforeLabel
@@ -45,6 +47,7 @@ import com.smarttoolfactory.beforeafter.OverlayStyle
 import com.smarttoolfactory.composebeforeafter.R
 import kotlin.math.roundToInt
 
+@OptIn(UnstableApi::class)
 @Composable
 fun BeforeAfterLayoutDemo() {
 
@@ -52,31 +55,31 @@ fun BeforeAfterLayoutDemo() {
         modifier = Modifier
             .fillMaxSize()
             .padding(10.dp)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(rememberScrollState()),
     ) {
 
         val imageBefore = ImageBitmap.imageResource(
-            LocalContext.current.resources, R.drawable.image_before_after_shoes_a
+            LocalContext.current.resources, R.drawable.image_before_after_shoes_a,
         )
 
         val imageAfter = ImageBitmap.imageResource(
-            LocalContext.current.resources, R.drawable.image_before_after_shoes_b
+            LocalContext.current.resources, R.drawable.image_before_after_shoes_b,
         )
 
 
         val imageBefore2 = ImageBitmap.imageResource(
-            LocalContext.current.resources, R.drawable.landscape5_before
+            LocalContext.current.resources, R.drawable.landscape5_before,
         )
 
         val imageAfter2 = ImageBitmap.imageResource(
-            LocalContext.current.resources, R.drawable.landscape5
+            LocalContext.current.resources, R.drawable.landscape5,
         )
         Text(
             text = "BeforeAfterLayout",
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
 
         Text(
@@ -84,7 +87,7 @@ fun BeforeAfterLayoutDemo() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
 
         BeforeAfterLayout(
@@ -103,8 +106,10 @@ fun BeforeAfterLayoutDemo() {
                 dividerWidth = 2.dp,
                 thumbShape = CutCornerShape(8.dp),
                 thumbBackgroundColor = Color.Red,
-                thumbTintColor = Color.White
-            )
+                thumbTintColor = Color.White,
+            ),
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
 
@@ -114,7 +119,7 @@ fun BeforeAfterLayoutDemo() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
 
         BeforeAfterLayout(
@@ -128,7 +133,9 @@ fun BeforeAfterLayoutDemo() {
             afterContent = {
                 DemoImage(imageBitmap = imageAfter2)
             },
-            contentOrder = ContentOrder.AfterBefore
+            contentOrder = ContentOrder.AfterBefore,
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
         Spacer(modifier = Modifier.height(50.dp))
@@ -142,10 +149,10 @@ fun BeforeAfterLayoutDemo() {
             animationSpec = infiniteRepeatable(
                 animation = tween(
                     durationMillis = 4000,
-                    easing = FastOutSlowInEasing
+                    easing = FastOutSlowInEasing,
                 ),
-                repeatMode = RepeatMode.Reverse
-            )
+                repeatMode = RepeatMode.Reverse,
+            ),
         )
 
 
@@ -154,7 +161,7 @@ fun BeforeAfterLayoutDemo() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
         BeforeAfterLayout(
             modifier = Modifier
@@ -171,7 +178,9 @@ fun BeforeAfterLayoutDemo() {
             enableZoom = false,
             beforeLabel = null,
             afterLabel = null,
-            overlay = null
+            overlay = null,
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
 
         Spacer(modifier = Modifier.height(50.dp))
@@ -181,7 +190,7 @@ fun BeforeAfterLayoutDemo() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
 
         BeforeAfterLayout(
@@ -199,7 +208,7 @@ fun BeforeAfterLayoutDemo() {
                 AfterLabel(text = "Material Design3")
             },
             enableZoom = false,
-            overlayStyle = OverlayStyle(thumbPositionPercent = 60f)
+            overlayStyle = OverlayStyle(thumbPositionPercent = 60f),
         )
 
         // FIXME There is a bug with Exoplayer2 and setting Modifier.graphicsLayer
@@ -212,7 +221,7 @@ fun BeforeAfterLayoutDemo() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(8.dp),
         )
         BeforeAfterLayout(
             modifier = Modifier
@@ -222,17 +231,19 @@ fun BeforeAfterLayoutDemo() {
                 MyPlayer(
                     modifier = Modifier
                         .border(3.dp, Color.Red),
-                    uri = "asset:///floodplain_dirty.mp4"
+                    uri = "asset:///floodplain_dirty.mp4",
                 )
             },
             afterContent = {
                 MyPlayer(
                     modifier = Modifier
                         .border(3.dp, Color.Yellow),
-                    uri = "asset:///floodplain_clean.mp4"
+                    uri = "asset:///floodplain_clean.mp4",
                 )
             },
-            enableZoom = false
+            enableZoom = false,
+            onProgressStart = { println("Slider move: Start") },
+            onProgressEnd = {  println("Slider move: End") },
         )
     }
 }
@@ -245,7 +256,7 @@ private fun DemoImage(imageBitmap: ImageBitmap) {
             .aspectRatio(4 / 3f),
         bitmap = imageBitmap,
         contentDescription = null,
-        contentScale = ContentScale.FillBounds
+        contentScale = ContentScale.FillBounds,
     )
 }
 
@@ -258,12 +269,12 @@ private fun BeforeComposable(progress: Float) {
             .clip(RoundedCornerShape(50))
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primary),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = "${(progress).roundToInt()}%",
             fontSize = 40.sp,
-            color = MaterialTheme.colorScheme.onPrimary
+            color = MaterialTheme.colorScheme.onPrimary,
         )
     }
 
@@ -274,14 +285,14 @@ private fun AfterComposable(progress: Float) {
     Column(
         modifier = Modifier
             .border(3.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(50))
-//            .clip(RoundedCornerShape(50))
+            .clip(RoundedCornerShape(50))
             .fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = "${(progress).roundToInt()}%",
             fontSize = 40.sp,
-            color = MaterialTheme.colorScheme.primary
+            color = MaterialTheme.colorScheme.primary,
         )
     }
 }

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImage.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImage.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.layout.ContentScale
  * @param beforeImage image that show initial progress
  * @param afterImage image that show final progress
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param overlayStyle styling values for [DefaultOverlay] to set divier color, thumb shape, size,
  * elevation and other properties
@@ -48,6 +50,8 @@ fun BeforeAfterImage(
     beforeImage: ImageBitmap,
     afterImage: ImageBitmap,
     enableProgressWithTouch: Boolean = true,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     overlayStyle: OverlayStyle = OverlayStyle(),
@@ -70,18 +74,19 @@ fun BeforeAfterImage(
         onProgressChange = {
             progress = it
         },
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentScale = contentScale,
         alignment = alignment,
         beforeLabel = beforeLabel,
         afterLabel = afterLabel,
         contentDescription = contentDescription,
     ) {
-
         DefaultOverlay(
             width = imageWidth,
             height = imageHeight,
             position = position,
-            overlayStyle = overlayStyle
+            overlayStyle = overlayStyle,
         )
     }
 }
@@ -100,14 +105,21 @@ fun BeforeAfterImage(
  * @param overlayStyle styling values for [DefaultOverlay] to set divier color, thumb shape, size,
  * elevation and other properties
  * @param contentOrder order of images to be drawn
+ * @param progress progress value that will be used to show progress
+ * @param onProgressChange callback that will be called when progress value changes
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
+ * @param overlayStyle styling values for [DefaultOverlay] to set divier color, thumb shape, size, elevation and other properties
+ * @param beforeLabel text that will be shown on top of image
+ * @param afterLabel text that will be shown on bottom of image
+ * @param contentScale how image should be scaled inside Canvas to match parent dimensions.
+  * [ContentScale.Fit] for instance maintains src ratio and scales image to fit inside the parent.
  * @param alignment determines where image will be aligned inside [BoxWithConstraints]
  * This is observable when bitmap image/width ratio differs from [Canvas] that draws [ImageBitmap]
  * @param contentDescription text used by accessibility services to describe what this image
  * represents. This should always be provided unless this image is used for decorative purposes,
  * and does not represent a meaningful action that a user can take. This text should be
  * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
- * @param contentScale how image should be scaled inside Canvas to match parent dimensions.
- * [ContentScale.Fit] for instance maintains src ratio and scales image to fit inside the parent.
  */
 @Composable
 fun BeforeAfterImage(
@@ -119,6 +131,8 @@ fun BeforeAfterImage(
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
     onProgressChange: ((Float) -> Unit)? = null,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     overlayStyle: OverlayStyle = OverlayStyle(),
     beforeLabel: @Composable BoxScope.() -> Unit = { BeforeLabel(contentOrder = contentOrder) },
     afterLabel: @Composable BoxScope.() -> Unit = { AfterLabel(contentOrder = contentOrder) },
@@ -135,18 +149,19 @@ fun BeforeAfterImage(
         contentOrder = contentOrder,
         progress = progress,
         onProgressChange = onProgressChange,
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentScale = contentScale,
         alignment = alignment,
         beforeLabel = beforeLabel,
         afterLabel = afterLabel,
         contentDescription = contentDescription,
     ) {
-
         DefaultOverlay(
             width = imageWidth,
             height = imageHeight,
             position = position,
-            overlayStyle = overlayStyle
+            overlayStyle = overlayStyle,
         )
     }
 }
@@ -163,6 +178,10 @@ fun BeforeAfterImage(
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param contentOrder order of images to be drawn
+ * @param progress progress value between 0.0f and 1.0f representing progress of image
+ * @param onProgressChange callback that is called when progress value changes
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param alignment determines where image will be aligned inside [BoxWithConstraints]
  * This is observable when bitmap image/width ratio differs from [Canvas] that draws [ImageBitmap]
  * @param contentDescription text used by accessibility services to describe what this image
@@ -191,6 +210,8 @@ fun BeforeAfterImage(
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
     onProgressChange: ((Float) -> Unit)? = null,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     contentDescription: String? = null,
@@ -199,15 +220,16 @@ fun BeforeAfterImage(
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     beforeLabel: @Composable BoxScope.() -> Unit = { BeforeLabel(contentOrder = contentOrder) },
     afterLabel: @Composable BoxScope.() -> Unit = { AfterLabel(contentOrder = contentOrder) },
-    overlay: @Composable BeforeAfterImageScope.() -> Unit
+    overlay: @Composable BeforeAfterImageScope.() -> Unit,
 ) {
-
     BeforeAfterImageImpl(
         modifier = modifier,
         beforeImage = beforeImage,
         afterImage = afterImage,
         progress = progress,
         onProgressChange = onProgressChange,
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,
@@ -219,7 +241,7 @@ fun BeforeAfterImage(
         filterQuality = filterQuality,
         beforeLabel = beforeLabel,
         afterLabel = afterLabel,
-        overlay = overlay
+        overlay = overlay,
     )
 }
 
@@ -233,6 +255,8 @@ fun BeforeAfterImage(
  * @param beforeImage image that show initial progress
  * @param afterImage image that show final progress
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param contentOrder order of images to be drawn
  * @param alignment determines where image will be aligned inside [BoxWithConstraints]
@@ -259,6 +283,8 @@ fun BeforeAfterImage(
     beforeImage: ImageBitmap,
     afterImage: ImageBitmap,
     enableProgressWithTouch: Boolean = true,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     alignment: Alignment = Alignment.Center,
@@ -269,7 +295,7 @@ fun BeforeAfterImage(
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     beforeLabel: @Composable BoxScope.() -> Unit = { BeforeLabel(contentOrder = contentOrder) },
     afterLabel: @Composable BoxScope.() -> Unit = { AfterLabel(contentOrder = contentOrder) },
-    overlay: @Composable BeforeAfterImageScope.() -> Unit
+    overlay: @Composable BeforeAfterImageScope.() -> Unit,
 ) {
     var progress by remember { mutableStateOf(50f) }
 
@@ -281,6 +307,8 @@ fun BeforeAfterImage(
         onProgressChange = {
             progress = it
         },
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,
@@ -292,6 +320,6 @@ fun BeforeAfterImage(
         filterQuality = filterQuality,
         beforeLabel = beforeLabel,
         afterLabel = afterLabel,
-        overlay = overlay
+        overlay = overlay,
     )
 }

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImageImpl.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImageImpl.kt
@@ -88,6 +88,8 @@ internal fun BeforeAfterImageImpl(
     afterImage: ImageBitmap,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
     onProgressChange: ((Float) -> Unit)? = null,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableProgressWithTouch: Boolean = true,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
@@ -199,6 +201,9 @@ internal fun BeforeAfterImageImpl(
 
                     isHandleTouched =
                         ((rawOffset.x - xPos) * (rawOffset.x - xPos) < 5000)
+
+                    onProgressStart?.invoke()
+                    it.consume()
                 },
                 onMove = {
                     if (isHandleTouched) {
@@ -211,6 +216,8 @@ internal fun BeforeAfterImageImpl(
                 },
                 onUp = {
                     isHandleTouched = false
+                    onProgressEnd?.invoke()
+                    it.consume()
                 }
             )
         }

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayout.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayout.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.unit.DpSize
  * based on [contentOrder]. This overload uses [DefaultOverlay] to draw vertical slider and thumb.
  *
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param contentOrder order of composables to be drawn
  * @param overlayStyle styling values for [DefaultOverlay] to set divier color, thumb shape, size,
@@ -30,6 +32,8 @@ import androidx.compose.ui.unit.DpSize
 fun BeforeAfterLayout(
     modifier: Modifier = Modifier,
     enableProgressWithTouch: Boolean = true,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     overlayStyle: OverlayStyle = OverlayStyle(),
@@ -50,6 +54,8 @@ fun BeforeAfterLayout(
         onProgressChange = {
             progress = it
         },
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,
@@ -71,6 +77,8 @@ fun BeforeAfterLayout(
  * [progress] value.
  *
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param contentOrder order of composables to be drawn
  * @param progress current position or progress of before/after
@@ -86,6 +94,8 @@ fun BeforeAfterLayout(
 fun BeforeAfterLayout(
     modifier: Modifier = Modifier,
     enableProgressWithTouch: Boolean = true,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
@@ -105,6 +115,8 @@ fun BeforeAfterLayout(
         afterLabel = afterLabel,
         progress = progress,
         onProgressChange = onProgressChange,
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,
@@ -124,6 +136,8 @@ fun BeforeAfterLayout(
  * based on [contentOrder].
  *
  * @param enableProgressWithTouch flag to enable drag and change progress with touch
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param enableZoom when enabled images are zoomable and pannable
  * @param contentOrder order of composables to be drawn
 
@@ -139,6 +153,8 @@ fun BeforeAfterLayout(
 fun BeforeAfterLayout(
     modifier: Modifier = Modifier,
     enableProgressWithTouch: Boolean = true,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
     beforeContent: @Composable () -> Unit,
@@ -159,6 +175,8 @@ fun BeforeAfterLayout(
         onProgressChange = {
             progress = it
         },
+        onProgressEnd = onProgressEnd,
+        onProgressStart  = onProgressStart,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,
@@ -176,6 +194,8 @@ fun BeforeAfterLayout(
  * @param progress current position or progress of before/after
  * @param onProgressChange current position or progress of before/after
  * It's between [0f-100f] to set thumb's vertical position in layout
+ * @param onProgressStart callback to be called when user starts dragging the slider with touch
+ * @param onProgressEnd callback to be called when user ends dragging the slider with touch
  * @param beforeContent content to be drawn as before Composable
  * @param afterContent content to be drawn as after Composable
  * @param beforeLabel label for [beforeContent]. It's [BeforeLabel] by default
@@ -188,6 +208,8 @@ fun BeforeAfterLayout(
     modifier: Modifier = Modifier,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
     onProgressChange: ((Float) -> Unit)? = null,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableProgressWithTouch: Boolean = true,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
@@ -206,6 +228,8 @@ fun BeforeAfterLayout(
         afterLabel = afterLabel,
         progress = progress,
         onProgressChange = onProgressChange,
+        onProgressStart = onProgressStart,
+        onProgressEnd = onProgressEnd,
         contentOrder = contentOrder,
         enableProgressWithTouch = enableProgressWithTouch,
         enableZoom = enableZoom,

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
@@ -35,6 +35,8 @@ internal fun Layout(
     modifier: Modifier = Modifier,
     @FloatRange(from = 0.0, to = 100.0) progress: Float = 50f,
     onProgressChange: ((Float) -> Unit)? = null,
+    onProgressStart: (() -> Unit)? = null,
+    onProgressEnd: (() -> Unit)? = null,
     enableProgressWithTouch: Boolean = true,
     enableZoom: Boolean = true,
     contentOrder: ContentOrder = ContentOrder.BeforeAfter,
@@ -110,6 +112,9 @@ internal fun Layout(
 
                         isHandleTouched =
                             ((rawOffset.x - xPos) * (rawOffset.x - xPos) < 5000)
+
+                        onProgressStart?.invoke()
+                        it.consume()
                     },
                     onMove = {
                         if (isHandleTouched) {
@@ -122,6 +127,8 @@ internal fun Layout(
                     },
                     onUp = {
                         isHandleTouched = false
+                        onProgressEnd?.invoke()
+                        it.consume()
                     }
                 )
             }


### PR DESCRIPTION
Added 2 callbacks in Composable function:

```kt
    onProgressStart: (() -> Unit)? = null,
    onProgressEnd: (() -> Unit)? = null,
```

The usecase for this is usually just tracking, although there are more possiblities.

It would be beneficial to know when a user has started moving the slider and then stopped.

> Demo app is updated to include print statements when these callbacks are triggered.
> Also updated the kdoc sections

## Demo

![Screen Recording 2024-09-15 at 22 20 55](https://github.com/user-attachments/assets/5e6404b2-1a1f-4066-b7e5-cdd061814b56)

