### PR TITLE
Fix: Only trigger onProgress callbacks when handle is touched

### DIFF
--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImageImpl.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImageImpl.kt
@@ -202,7 +202,9 @@ internal fun BeforeAfterImageImpl(
                     isHandleTouched =
                         ((rawOffset.x - xPos) * (rawOffset.x - xPos) < 5000)
 
-                    onProgressStart?.invoke()
+                    if (isHandleTouched) {
+                        onProgressStart?.invoke()
+                    }
                     it.consume()
                 },
                 onMove = {
@@ -215,8 +217,10 @@ internal fun BeforeAfterImageImpl(
                     }
                 },
                 onUp = {
+                    if(isHandleTouched) {
+                        onProgressEnd?.invoke()
+                    }
                     isHandleTouched = false
-                    onProgressEnd?.invoke()
                     it.consume()
                 }
             )

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
@@ -113,7 +113,9 @@ internal fun Layout(
                         isHandleTouched =
                             ((rawOffset.x - xPos) * (rawOffset.x - xPos) < 5000)
 
-                        onProgressStart?.invoke()
+                        if (isHandleTouched) {
+                            onProgressStart?.invoke()
+                        }
                         it.consume()
                     },
                     onMove = {
@@ -126,8 +128,10 @@ internal fun Layout(
                         }
                     },
                     onUp = {
+                        if(isHandleTouched) {
+                            onProgressEnd?.invoke()
+                        }
                         isHandleTouched = false
-                        onProgressEnd?.invoke()
                         it.consume()
                     }
                 )


### PR DESCRIPTION
Currently the callbacks are also triggered if one touches on the before/after composable area.

This is not ideal. These callbacks should only be fired when the user is touching the handle and sliding, reflecting the change in progress.

This PR fixes that issue :) 

### Before:

https://github.com/user-attachments/assets/079a3bb1-2d78-4596-98dc-9f42af8c650a



### After:

https://github.com/user-attachments/assets/5d4a4b9f-ae82-402e-8acc-ec789822bee4

