### PR TITLE
Fix: Slider thumb track position and shadow

### DIFF
--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/DefaultOverlay.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/DefaultOverlay.kt
@@ -85,17 +85,16 @@ internal fun DefaultOverlay(
         val horizontalOffset = imageWidthInPx / 2
         val verticalOffset = imageHeightInPx / 2
 
+        val thumbMinY = -verticalOffset + thumbRadius
+        val thumbMaxY = verticalOffset - thumbRadius
+
         linePosition = thumbPosX.coerceIn(0f, imageWidthInPx)
         thumbPosX -= horizontalOffset
 
         thumbPosY = if (verticalThumbMove) {
-            (thumbPosY - verticalOffset)
-                .coerceIn(
-                    -verticalOffset + thumbRadius,
-                    verticalOffset - thumbRadius
-                )
+            (thumbPosY - verticalOffset).coerceIn(thumbMinY, thumbMaxY)
         } else {
-            ((imageHeightInPx * thumbPositionPercent / 100f - thumbRadius) - verticalOffset)
+            (imageHeightInPx * thumbPositionPercent / 100f) - verticalOffset
         }
     }
 
@@ -164,5 +163,5 @@ class OverlayStyle(
     val thumbElevation: Dp = 2.dp,
     @DrawableRes val thumbResource: Int = R.drawable.baseline_swap_horiz_24,
     val thumbSize: Dp = 36.dp,
-    @FloatRange(from = 0.0, to = 100.0) val thumbPositionPercent: Float = 85f,
+    @FloatRange(from = 0.0, to = 100.0) val thumbPositionPercent: Float = 50f,
 )

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/DefaultOverlay.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/DefaultOverlay.kt
@@ -13,8 +13,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -56,6 +60,15 @@ internal fun DefaultOverlay(
     val thumbSize = overlayStyle.thumbSize
     val thumbPositionPercent = overlayStyle.thumbPositionPercent
 
+    val shadow by remember {
+        derivedStateOf {
+            if (thumbBackgroundColor == Color.Transparent) {
+                0.dp
+            } else {
+                thumbElevation
+            }
+        }
+    }
 
     var thumbPosX = position.x
     var thumbPosY = position.y
@@ -115,7 +128,8 @@ internal fun DefaultOverlay(
                 .offset {
                     IntOffset(thumbPosX.toInt(), thumbPosY.toInt())
                 }
-                .shadow(thumbElevation, thumbShape)
+                .clip(thumbShape)
+                .shadow(shadow)
                 .background(thumbBackgroundColor)
                 .size(thumbSize)
                 .padding(4.dp)


### PR DESCRIPTION
There are 2 issues this PR fixes.

### Issue 1: The position of thumb track doesn't match the percentage specified i.e for 50% the thumb track is not in the middle of the screen.

Before:

<img width="1411" alt="Screenshot 2024-10-06 at 16 33 09" src="https://github.com/user-attachments/assets/ef84f52c-a093-4468-913f-0f2c26d8d8b0">

After:

<img width="1433" alt="Screenshot 2024-10-06 at 16 33 39" src="https://github.com/user-attachments/assets/ef43561c-f6a2-4ce8-a4ca-b13f8b40846d">

---

### Issue 2: When setting the background color to transparent in thumbtrack the shadow is shown, which is not desirable.

Before:

<img width="1323" alt="Screenshot 2024-10-06 at 16 36 06" src="https://github.com/user-attachments/assets/6920263a-1310-4bd2-a57a-8cfd00f42546">

After:

<img width="1321" alt="Screenshot 2024-10-06 at 16 34 18" src="https://github.com/user-attachments/assets/92ae54ab-bf9d-4a79-bd6e-9bb861fa3886">


