### PR TITLE
Trigger Jitpack build using Github Actions

### DIFF
--- a/.github/workflows/trigger-build-on-jitpack.yml
+++ b/.github/workflows/trigger-build-on-jitpack.yml
@@ -1,0 +1,33 @@
+name: Trigger Build on Jitpack
+
+env:
+  SDK_NAME: "Compose-BeforeAfter" # Define the repository name (SDK)
+  USERNAME: "SmartToolFactory" # GitHub username for the Maven coordinates
+
+on:
+  push:
+    paths-ignore:
+      - "**/*.md" # Ignore markdown files to prevent unnecessary builds
+    branches:
+      - master # Trigger build when a commit lands on the master branch
+    tags:
+      - "*" # Trigger build when a new tag is pushed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger Jitpack Build for Tagged Release
+        if: startsWith(github.ref, 'refs/tags/') # Only trigger for new tags
+        run: |
+          # Request Jitpack to build the SDK for the specific tag version
+          curl https://jitpack.io/api/builds/com.github.${{ env.USERNAME }}/${{ env.SDK_NAME }}/${{ github.ref_name }}
+
+      - name: Trigger Jitpack Build for Master-SNAPSHOT
+        if: github.ref == 'refs/heads/master' # Only trigger when a commit is pushed to master
+        run: |
+          # Request Jitpack to build the latest snapshot for master
+          curl https://jitpack.io/api/builds/com.github.${{ env.USERNAME }}/${{ env.SDK_NAME }}/master-SNAPSHOT

--- a/.github/workflows/trigger-build-on-jitpack.yml
+++ b/.github/workflows/trigger-build-on-jitpack.yml
@@ -3,6 +3,7 @@ name: Trigger Build on Jitpack
 env:
   SDK_NAME: "Compose-BeforeAfter" # Define the repository name (SDK)
   USERNAME: "SmartToolFactory" # GitHub username for the Maven coordinates
+  BASE_URL: "https://jitpack.io/api/builds/com.github.${{ env.USERNAME }}/${{ env.SDK_NAME }}" # Common base URL for Jitpack builds
 
 on:
   push:
@@ -24,10 +25,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') # Only trigger for new tags
         run: |
           # Request Jitpack to build the SDK for the specific tag version
-          curl https://jitpack.io/api/builds/com.github.${{ env.USERNAME }}/${{ env.SDK_NAME }}/${{ github.ref_name }}
+          curl "${{ env.BASE_URL }}/${{ github.ref_name }}"
 
       - name: Trigger Jitpack Build for Master-SNAPSHOT
         if: github.ref == 'refs/heads/master' # Only trigger when a commit is pushed to master
         run: |
           # Request Jitpack to build the latest snapshot for master
-          curl https://jitpack.io/api/builds/com.github.${{ env.USERNAME }}/${{ env.SDK_NAME }}/master-SNAPSHOT
+          curl "${{ env.BASE_URL }}/master-SNAPSHOT"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate triggering builds on Jitpack for the repository. The workflow is designed to handle both tagged releases and updates to the master branch.

### New GitHub Actions Workflow:
* `.github/workflows/trigger-build-on-jitpack.yml`: Added a workflow named "Trigger Build on Jitpack" to automate build requests to Jitpack. It triggers builds for:
  * Tagged releases: Requests Jitpack to build the SDK for specific tag versions.
  * Master branch updates: Requests Jitpack to build the latest snapshot for the master branch.
* Configured to ignore markdown file changes and only trigger for changes to the master branch or new tags.