### PR TITLE
Fixes issue with ExoPlayer inside BeforeAfterLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ https://github.com/user-attachments/assets/60a3b755-046f-4683-b3eb-cd89fb728d64
 
 To get a Git project into your build:
 
-**Step 1:** Add the JitPack repository to your build file Add it in your root build.gradle at the end
-  of repositories:
+**Step 1:** Add the JitPack repository to your build file Add it in your root build.gradle at the end of repositories:
 
 ```gradle
 allprojects {
@@ -313,12 +312,7 @@ BeforeAfterLayout(
 
 ### Display before and after videos with Exoplayer
 
-> [!WARNING]  
-> Note there is a bug with Exoplayer2
-
-If you have a fix please open a PR or answer
-[this question](https://stackoverflow.com/questions/73061216/exoplayer2-with-before-after-videos-changes-first-video-when-clip-and-shape-used)
-Both are appreciated greatly
+There is `ExoPlayerUsingTextureView` composable that you can use to display before and after videos.
 
 ```kotlin
 BeforeAfterLayout(
@@ -326,19 +320,25 @@ BeforeAfterLayout(
         .fillMaxSize()
         .aspectRatio(4 / 3f),
     beforeContent = {
-        MyPlayer(
-            modifier = Modifier
-                .border(3.dp, Color.Red),
+        ExoPlayerUsingTextureView(
             uri = "asset:///floodplain_dirty.mp4"
         )
     },
     afterContent = {
-        MyPlayer(
-            modifier = Modifier
-                .border(3.dp, Color.Yellow),
+        ExoPlayerUsingTextureView(
             uri = "asset:///floodplain_clean.mp4"
         )
     },
     enableZoom = false
 )
 ```
+
+> [!NOTE]  
+> If you would like the ability to customize and build your own VideoPlayer composable using Exoplayer, then take a look at the implementation of `ExoPlayerUsingTextureView` composable. You can duplicate the composable and modify the behaviour.
+>
+> Only thing to take care of is that `BeforeAfterLayout` requires Exoplayer that works with a TextureView.
+> Inside the `ExoPlayerUtil` is a public extension function named `ExoPlayer.createTextureView` that you should use with your ExoPlayer.
+
+## License
+
+[Apache License, Version 2.0](LICENSE.md)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,8 +47,4 @@ dependencies {
 
     // For media playback using ExoPlayer
     implementation libs.androidx.media3.exoplayer
-    // For building media playback UIs
-    implementation libs.androidx.media3.ui
-    // Common functionality used across multiple media libraries
-    implementation libs.androidx.media3.common
 }

--- a/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterLayoutDemo.kt
+++ b/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/BeforeAfterLayoutDemo.kt
@@ -39,10 +39,10 @@ import com.smarttoolfactory.beforeafter.BeforeAfterLayout
 import com.smarttoolfactory.beforeafter.BeforeLabel
 import com.smarttoolfactory.beforeafter.ContentOrder
 import com.smarttoolfactory.beforeafter.OverlayStyle
+import com.smarttoolfactory.beforeafter.util.ExoPlayerUsingTextureView
 import com.smarttoolfactory.composebeforeafter.R
 import com.smarttoolfactory.composebeforeafter.demo.components.M2BeforeSample
 import com.smarttoolfactory.composebeforeafter.demo.components.M3AfterSample
-import com.smarttoolfactory.composebeforeafter.demo.components.MyPlayer
 import com.smarttoolfactory.composebeforeafter.demo.helpers.SectionDividerSpace
 import com.smarttoolfactory.composebeforeafter.demo.helpers.SectionTitle
 import com.smarttoolfactory.composebeforeafter.demo.helpers.imageBitmapFromRes
@@ -183,16 +183,12 @@ internal fun BeforeAfterLayoutDemo() {
                 .fillMaxSize()
                 .aspectRatio(4 / 3f),
             beforeContent = {
-                MyPlayer(
-                    modifier = Modifier
-                        .border(3.dp, Color.Red),
+                ExoPlayerUsingTextureView(
                     uri = "asset:///floodplain_dirty.mp4",
                 )
             },
             afterContent = {
-                MyPlayer(
-                    modifier = Modifier
-                        .border(3.dp, Color.Yellow),
+                ExoPlayerUsingTextureView(
                     uri = "asset:///floodplain_clean.mp4",
                 )
             },

--- a/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/components/SampleExoPlayer.kt
+++ b/app/src/main/java/com/smarttoolfactory/composebeforeafter/demo/components/SampleExoPlayer.kt
@@ -1,6 +1,7 @@
 package com.smarttoolfactory.composebeforeafter.demo.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -44,6 +45,14 @@ internal fun MyPlayer(modifier: Modifier, uri: String) {
         modifier = modifier,
         factory = {
             playerView
-        }
+        },
     )
+
+    // Clean up the ExoPlayer when the composable is disposed
+    DisposableEffect(Unit) {
+        onDispose {
+            exoPlayer.release()
+            playerView.player = null
+        }
+    }
 }

--- a/beforeafter/build.gradle
+++ b/beforeafter/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 
     implementation libs.androidx.compose.ui.ui.tooling
     implementation libs.androidx.runtime
+
+    compileOnly libs.androidx.media3.exoplayer
 }
 
 

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImage.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImage.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -196,18 +197,12 @@ internal fun Layout(
 
             val beforeModifier = Modifier
                 .fillMaxSize()
-                .graphicsLayer {
-                    this.clip = true
-                    this.shape = shapeBefore
-                }
+                .clip(shapeBefore)
 
 
             val afterModifier = Modifier
                 .fillMaxSize()
-                .graphicsLayer {
-                    this.clip = true
-                    this.shape = shapeAfter
-                }
+                .clip(shapeAfter)
 
             LayoutImpl(
                 modifier = parentModifier,

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUsingTextureView.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUsingTextureView.kt
@@ -1,4 +1,4 @@
-package com.smarttoolfactory.composebeforeafter.demo.components
+package com.smarttoolfactory.beforeafter.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -9,22 +9,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.AspectRatioFrameLayout
-import androidx.media3.ui.PlayerView
 
-@UnstableApi
 @Composable
-internal fun MyPlayer(modifier: Modifier, uri: String) {
+fun ExoPlayerUsingTextureView(modifier: Modifier = Modifier, uri: String) {
     val context = LocalContext.current
     val exoPlayer = ExoPlayer.Builder(context).build()
-    val playerView = remember {
-        PlayerView(context)
-    }
-
-
-    println("🚀 MyPlayer URI $uri, player: $exoPlayer, playerView: $playerView")
+    val textureView = remember { exoPlayer.createTextureView(context) }
 
     LaunchedEffect(exoPlayer, uri) {
         with(exoPlayer) {
@@ -33,26 +24,21 @@ internal fun MyPlayer(modifier: Modifier, uri: String) {
             prepare()
             playWhenReady = true
         }
-
-        with(playerView) {
-            useController = false
-            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
-            player = exoPlayer
-        }
     }
 
     AndroidView(
         modifier = modifier,
-        factory = {
-            playerView
-        },
+        factory = { textureView },
     )
 
     // Clean up the ExoPlayer when the composable is disposed
     DisposableEffect(Unit) {
         onDispose {
             exoPlayer.release()
-            playerView.player = null
         }
     }
 }
+
+
+
+

--- a/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUtil.kt
+++ b/beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUtil.kt
@@ -1,0 +1,51 @@
+package com.smarttoolfactory.beforeafter.util
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.view.Surface
+import android.view.TextureView
+import androidx.media3.exoplayer.ExoPlayer
+
+/**
+ * Extension function for ExoPlayer to create and configure a TextureView for video rendering.
+ *
+ * This function initializes a TextureView and sets up a SurfaceTextureListener to manage the rendering surface.
+ * It ensures proper handling of surface availability, resizing, and destruction, making ExoPlayer compatible with Compose.
+ *
+ * @receiver ExoPlayer The ExoPlayer instance that will be bound to the TextureView.
+ * @param context The Android context used to instantiate the TextureView.
+ * @return TextureView A configured TextureView that can be used for rendering video.
+ */
+fun ExoPlayer.createTextureView(context: Context): TextureView {
+    return TextureView(context).apply {
+        // Listen for surface events to correctly bind ExoPlayer to TextureView
+        surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+            override fun onSurfaceTextureAvailable(
+                surface: SurfaceTexture,
+                width: Int,
+                height: Int,
+            ) {
+                // Bind the TextureView surface to ExoPlayer
+                this@createTextureView.setVideoSurface(Surface(surface))
+            }
+
+            override fun onSurfaceTextureSizeChanged(
+                surface: SurfaceTexture,
+                width: Int,
+                height: Int,
+            ) {
+                // Handle changes in TextureView size if needed (e.g., aspect ratio adjustments)
+            }
+
+            override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                // Remove the surface from ExoPlayer to prevent memory leaks
+                this@createTextureView.setVideoSurface(null)
+                return true // Allow texture cleanup
+            }
+
+            override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+                // Called when a new video frame is available; usually no action needed here
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #27 

This pull request introduces a significant update to the `BeforeAfter` library by replacing the `MyPlayer` implementation with a new `ExoPlayerUsingTextureView` composable, simplifying video rendering, and improving compatibility with ExoPlayer. Additionally, it includes dependency changes, refactoring, and documentation updates.

### Major Changes by Theme:

#### Video Player Replacement and Refactoring:
* Replaced the `MyPlayer` composable with `ExoPlayerUsingTextureView` for rendering videos using a TextureView, improving compatibility with ExoPlayer and Compose. The new implementation includes proper resource cleanup via `DisposableEffect`. (`[[1]](diffhunk://#diff-e0c952c60567c34050ff57354575826e9a6b5acd2cf72c2f30ad362dfdca6a2eL1-R18)`, `[[2]](diffhunk://#diff-e0c952c60567c34050ff57354575826e9a6b5acd2cf72c2f30ad362dfdca6a2eL35-R44)`)
* Introduced the `ExoPlayer.createTextureView` extension function to encapsulate the logic for creating and managing a `TextureView` for ExoPlayer. (`[beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUtil.ktR1-R51](diffhunk://#diff-3e8f37d520b43b852c908c3e697cee896c7f904148a6fbc10f520991d601a27fR1-R51)`)
* Updated usage of `MyPlayer` to `ExoPlayerUsingTextureView` in `BeforeAfterLayoutDemo` and `BeforeAfterLayout`. (`[[1]](diffhunk://#diff-a821a496c8da08b0df619eb74be3d308b25074ac0b16ae6c92ba1ff6853b1a6bL186-R191)`, `[[2]](diffhunk://#diff-0362da9effe8712f5818723024c68648f04dbd7a1aab465e0e55a7d469aa122dL199-R205)`)

#### Dependency Updates:
* Removed unused dependencies related to ExoPlayer UI and media libraries in `app/build.gradle`. (`[app/build.gradleL50-L53](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L50-L53)`)
* Added `media3.exoplayer` as a `compileOnly` dependency in the `beforeafter` module to ensure modularity. (`[beforeafter/build.gradleR26-R27](diffhunk://#diff-4cc76bec5f7a857bec89bc309c877a6defe6c08e1f8771c47a4fa6fd164bdd6fR26-R27)`)

#### Code Simplification:
* Simplified clipping logic in `BeforeAfterLayoutImpl` by replacing `graphicsLayer` with the `clip` modifier. (`[beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterLayoutImpl.ktL199-R205](diffhunk://#diff-0362da9effe8712f5818723024c68648f04dbd7a1aab465e0e55a7d469aa122dL199-R205)`)
* Removed unused imports, such as `mutableStateOf`, across files for cleaner code. (`[beforeafter/src/main/java/com/smarttoolfactory/beforeafter/BeforeAfterImage.ktL10](diffhunk://#diff-adf6f9540da71667529af2e6c26c54ec99567d66c57cc184d2548c7e02cf88eeL10)`)

#### Documentation Updates:
* Updated the `README.md` to reflect the new `ExoPlayerUsingTextureView` composable, removing outdated warnings and adding guidance for customization. (`[README.mdL316-R344](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L316-R344)`)
* Fixed minor formatting issues in the `README.md`. (`[README.mdL15-R15](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15)`)

#### File Structure Improvements:
* Renamed `SampleExoPlayer.kt` to `ExoPlayerUsingTextureView.kt` and moved it to the `beforeafter.util` package for better organization and reusability. (`[beforeafter/src/main/java/com/smarttoolfactory/beforeafter/util/ExoPlayerUsingTextureView.ktL1-R18](diffhunk://#diff-e0c952c60567c34050ff57354575826e9a6b5acd2cf72c2f30ad362dfdca6a2eL1-R18)`)